### PR TITLE
ERM-2589: Increment stripes to Stripes v8

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-intl": "^5.8.1",
-    "@folio/stripes": "^7.3.1",
+    "@folio/stripes": "^7.3.1 || ^8.0.0",
     "@folio/stripes-cli": "^2.6.1"
   },
   "dependencies": {
@@ -31,7 +31,7 @@
     "prop-types": "^15.6.0"
   },
   "peerDependencies": {
-    "@folio/stripes": "^7.3.1",
+    "@folio/stripes": "^7.3.1 || ^8.0.0",
     "react": "^17.0.2",
     "react-intl": "^5.8.1",
     "react-router-dom": "^5.2.0"


### PR DESCRIPTION
build: Stripes

Bump stripes compatibility to include v8. Since this project will be used across Nolana/Orchid for the likes of ui-oa and ui-service-interaction, and the component is unaffected by the major stripes version bump, we declare compatibilty with both. Thus we do not bump major version here.

refs ERM-2589, ERM-2595