### PR TITLE
ERM-2997: Upgrade ui-handler-stripes-registry React to v18

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -2,7 +2,20 @@
   "extends": "@folio/eslint-config-stripes",
   "parser": "@babel/eslint-parser",
   "rules": {
-    "import/no-extraneous-dependencies": "off",
-    "react/jsx-sort-props": "error"
-  }
+    "react/jsx-sort-props": "error",
+    "no-unused-vars": [
+      "warn",
+      {
+        "argsIgnorePattern": "^_",
+        "varsIgnorePattern": "(React|^_)"
+      }
+    ]
+  },
+  "env": {
+    "jest": true
+  },
+  "plugins": [
+    "testing-library",
+    "jest-dom"
+  ]
 }

--- a/.github/workflows/build-npm-release.yml
+++ b/.github/workflows/build-npm-release.yml
@@ -28,7 +28,7 @@ jobs:
       FOLIO_NPM_REGISTRY: 'https://repository.folio.org/repository/npm-folio/'
       FOLIO_NPM_REGISTRY_AUTH: '//repository.folio.org/repository/npm-folio/'
       FOLIO_MD_REGISTRY: 'https://folio-registry.dev.folio.org'
-      NODEJS_VERSION: '16'
+      NODEJS_VERSION: '18'
       JEST_JUNIT_OUTPUT_DIR: 'artifacts/jest-junit'
       JEST_COVERAGE_REPORT_DIR: 'artifacts/coverage-jest/lcov-report/'
       BIGTEST_JUNIT_OUTPUT_DIR: 'artifacts/runTest'

--- a/.github/workflows/build-npm.yml
+++ b/.github/workflows/build-npm.yml
@@ -25,7 +25,7 @@ jobs:
       FOLIO_NPM_REGISTRY: 'https://repository.folio.org/repository/npm-folioci/'
       FOLIO_NPM_REGISTRY_AUTH: '//repository.folio.org/repository/npm-folioci/'
       FOLIO_MD_REGISTRY: 'https://folio-registry.dev.folio.org'
-      NODEJS_VERSION: '16'
+      NODEJS_VERSION: '18'
       JEST_JUNIT_OUTPUT_DIR: 'artifacts/jest-junit'
       JEST_COVERAGE_REPORT_DIR: 'artifacts/coverage-jest/lcov-report/'
       BIGTEST_JUNIT_OUTPUT_DIR: 'artifacts/runTest'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Change history for ui-handler-stripes-registry
 
-## 1.5.0 In progress
+## 2.0.0 In progress
+  * STRIPES-870 BREAKING upgrade react to v18
+    * ERM-2997 Upgrade ui-handler-stripes-registry React to v18
 
 ## 1.4.0 2023-02-22
 * ERM-2561 Increment ui-handler-stripes-registry to Stripes v8

--- a/package.json
+++ b/package.json
@@ -6,9 +6,6 @@
     "registry": "https://repository.folio.org/repository/npm-folio/"
   },
   "license": "Apache-2.0",
-  "engines": {
-    "node": ">=10.0.0"
-  },
   "scripts": {
     "lint": "eslint .",
     "build-mod-descriptor": "stripes mod descriptor --full --strict | jq '.[]' > module-descriptor.json ",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/handler-stripes-registry",
-  "version": "1.5.0",
+  "version": "2.0.0",
   "description": "frontend registry for Stripes",
   "publishConfig": {
     "registry": "https://repository.folio.org/repository/npm-folio/"
@@ -15,15 +15,15 @@
     "formatjs-compile": "formatjs compile-folder --ast --format simple ./translations/ui-handler-stripes-registry ./translations/ui-handler-stripes-registry/compiled"
   },
   "devDependencies": {
-    "@folio/eslint-config-stripes": "^6.3.0",
+    "@folio/eslint-config-stripes": "^7.0.0",
     "@formatjs/cli": "^4.2.31",
     "@babel/eslint-parser": "^7.15.0",
     "eslint": "^7.32.0",
-    "react": "^17.0.2",
-    "react-dom": "^17.0.2",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
     "react-intl": "^5.8.1",
-    "@folio/stripes": "^7.3.1 || ^8.0.0",
-    "@folio/stripes-cli": "^2.6.1"
+    "@folio/stripes": "^9.0.0",
+    "@folio/stripes-cli": "^3.0.0"
   },
   "dependencies": {
     "dom-helpers": "^3.4.0",
@@ -31,8 +31,8 @@
     "prop-types": "^15.6.0"
   },
   "peerDependencies": {
-    "@folio/stripes": "^7.3.1 || ^8.0.0",
-    "react": "^17.0.2",
+    "@folio/stripes": "^9.0.0",
+    "react": "^18.2.0",
     "react-intl": "^5.8.1",
     "react-router-dom": "^5.2.0"
   },


### PR DESCRIPTION
Update to react 18
Eslintrc change
Make use of `@folio/jest-config-stripes`
Tweak tests to make use of changed stripes-erm-testing shape, avoiding need for stripes-testing import Eslint changes
CHANGELOG section change
Bumped major version
Changed github actions node_version to 18
Removed node engines from package.json

refs ERM-2997, STRIPES-870 and ERM-3001