### PR TITLE
chore: Release 2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change history for ui-handler-stripes-registry
 
+## 2.0.1 2023-10-18
+  * SI-39 Update react-intl to v6
+
 ## 2.0.0 2023-10-12
   * ERM-3001 Update Nodejs to v18 in GitHub Actions
   * STRIPES-870 *BREAKING* upgrade react to v18

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "eslint": "^7.32.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-intl": "^5.8.1",
+    "react-intl": "^6.4.0",
     "@folio/stripes": "^9.0.0",
     "@folio/stripes-cli": "^3.0.0"
   },
@@ -30,7 +30,7 @@
   "peerDependencies": {
     "@folio/stripes": "^9.0.0",
     "react": "^18.2.0",
-    "react-intl": "^5.8.1",
+    "react-intl": "^6.4.0",
     "react-router-dom": "^5.2.0"
   },
   "stripes": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/handler-stripes-registry",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "frontend registry for Stripes",
   "publishConfig": {
     "registry": "https://repository.folio.org/repository/npm-folio/"


### PR DESCRIPTION
Updates react-intl dependencies to 6.4.0

Bumped version to 2.0.1
