### PR TITLE
ERM-3611: Stripes v10 dependencies update

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/handler-stripes-registry",
-  "version": "2.4.0",
+  "version": "3.0.0",
   "description": "frontend registry for Stripes",
   "publishConfig": {
     "registry": "https://repository.folio.org/repository/npm-folio/"
@@ -12,15 +12,15 @@
     "formatjs-compile": "formatjs compile-folder --ast --format simple ./translations/ui-handler-stripes-registry ./translations/ui-handler-stripes-registry/compiled"
   },
   "devDependencies": {
-    "@folio/eslint-config-stripes": "^7.1.0",
-    "@formatjs/cli": "^4.2.31",
+    "@folio/eslint-config-stripes": "^8.0.0",
+    "@formatjs/cli": "^6.6.0",
     "@babel/eslint-parser": "^7.15.0",
     "eslint": "^7.32.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-intl": "^6.4.0",
-    "@folio/stripes": "^9.2.0",
-    "@folio/stripes-cli": "^3.2.0"
+    "react-intl": "^7.1.5",
+    "@folio/stripes": "^10.0.0",
+    "@folio/stripes-cli": "^4.0.0"
   },
   "dependencies": {
     "dom-helpers": "^3.4.0",
@@ -28,9 +28,9 @@
     "prop-types": "^15.6.0"
   },
   "peerDependencies": {
-    "@folio/stripes": "^9.2.0",
+    "@folio/stripes": "^10.0.0",
     "react": "^18.2.0",
-    "react-intl": "^6.4.0",
+    "react-intl": "^7.1.5",
     "react-router-dom": "^5.2.0"
   },
   "stripes": {


### PR DESCRIPTION
BREAKING Updated all stripes-* dependencies for the stripes v10 upgrade along with react-intl and formatjs/cli

Bumped version to 3.0.0

ERM-3611